### PR TITLE
Chunks and ChunksMut should be public

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 sudo: required
 
 rust:
-  - 1.21.0
+  - 1.24.1
   - stable
   - beta
   - nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,4 +46,4 @@
 
 mod divbuf;
 
-pub use divbuf::{DivBufShared, DivBuf, DivBufMut};
+pub use divbuf::{Chunks, ChunksMut, DivBufShared, DivBuf, DivBufMut};


### PR DESCRIPTION
This was always intended to be the case.  They were still accessible as
the return values of the into_chunks and into_chunks_mut methods, so
this change is mostly just to the API documentation.