### PR TITLE
Test benchmarks in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,10 @@ test_task:
     folder: $CARGO_HOME/registry
   test_script:
     - cargo test
+  bench_script:
+    - if rustc --version | grep -q nightly; then
+    -   cargo test --bench '*'
+    - fi
   asan_script:
     - if rustc --version | grep -q nightly; then
     -   env RUSTFLAGS="-Z sanitizer=address" cargo test --tests

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -1,0 +1,22 @@
+#![feature(test)]
+
+extern crate test;
+
+use divbuf::*;
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::Hash
+};
+use test::Bencher;
+
+#[bench]
+fn bench_divbuf_hash(bench: &mut Bencher) {
+    let dbs = DivBufShared::from(vec![0u8; 8]);
+    let db = dbs.try_const().unwrap();
+    let mut hasher = DefaultHasher::new();
+
+    bench.bytes = db.len() as u64;
+    bench.iter(move || {
+        db.hash(&mut hasher);
+    })
+}


### PR DESCRIPTION
Cargo 1.49.0 and later allow running the benchmarks in debug mode,
perfect for CI.