### PR TITLE
clippy cleanup

### DIFF
--- a/src/divbuf.rs
+++ b/src/divbuf.rs
@@ -706,7 +706,7 @@ impl PartialEq<[u8]> for DivBuf {
 
 impl PartialOrd for DivBuf {
     fn partial_cmp(&self, other: &DivBuf) -> Option<cmp::Ordering> {
-        self.as_ref().partial_cmp(other.as_ref())
+        Some(self.cmp(other))
     }
 }
 
@@ -1110,7 +1110,7 @@ impl PartialEq<[u8]> for DivBufMut {
 
 impl PartialOrd for DivBufMut {
     fn partial_cmp(&self, other: &DivBufMut) -> Option<cmp::Ordering> {
-        self.as_ref().partial_cmp(other.as_ref())
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
clippy::incorrect_partial_ord_impl_on_ord_type

The old impls were actually correct.  Clippy is a bit too concerned here.  But shut it up anyway.