### PR TITLE
Explicitly install clippy during CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,6 +17,7 @@ test_task:
     - cargo test
   clippy_script:
     - if rustc --version | grep -q nightly; then
+    -   rustup component add clippy
     -   cargo clippy --all-targets -- -D warnings
     - fi
   audit_script:


### PR DESCRIPTION
It used to be inclued in the rust:latest container.  Apparently it no longer is.