### PR TITLE
During CI, run cargo-audit before clippy

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,15 +15,15 @@ test_task:
     folder: $CARGO_HOME/registry
   test_script:
     - cargo test
-  clippy_script:
-    - if rustc --version | grep -q nightly; then
-    -   rustup component add clippy
-    -   cargo clippy --all-targets -- -D warnings
-    - fi
   audit_script:
     - if rustc --version | grep -q nightly; then
     -   cargo install cargo-audit
     -   cargo audit
+    - fi
+  clippy_script:
+    - if rustc --version | grep -q nightly; then
+    -   rustup component add clippy
+    -   cargo clippy --all-targets -- -D warnings
     - fi
   bench_script:
     - if rustc --version | grep -q nightly; then


### PR DESCRIPTION
Because clippy will write a new lock file, and cargo-audit can't understand v4 lock files.