### PR TITLE
Gate the `DivBufShared::uninitialized` method behind a feature flag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,11 +14,11 @@ test_task:
   cargo_cache:
     folder: $CARGO_HOME/registry
   test_script:
-    - cargo test
+    - cargo test --all-features
   clippy_script:
     - if rustc --version | grep -q nightly; then
     -   rustup component add clippy
-    -   cargo clippy --all-targets -- -D warnings
+    -   cargo clippy --all-features --all-targets -- -D warnings
     - fi
   audit_script:
     - if rustc --version | grep -q nightly; then
@@ -27,7 +27,7 @@ test_task:
     - fi
   bench_script:
     - if rustc --version | grep -q nightly; then
-    -   cargo test --bench '*'
+    -   cargo test --all-features --bench '*'
     - fi
   fmt_script:
     - if rustc --version | grep -q nightly; then
@@ -36,7 +36,7 @@ test_task:
     - fi
   asan_script:
     - if rustc --version | grep -q nightly; then
-    -   env RUSTFLAGS="-Z sanitizer=address" cargo test --tests
+    -   env RUSTFLAGS="-Z sanitizer=address" cargo test --all-features --tests
     - fi
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   ([#15](https://github.com/asomers/divbuf/pull/15))
 
 - `DivBufShared::uninitialized` creates a DivBufShared with an uninitialized
-  buffer.
+  buffer.  It is gated by the `experimental` feature, and won't likely remain
+  in its current form indefinitely.
   ([#6](https://github.com/asomers/divbuf/pull/6))
 
 - `impl TryFrom<DivBufShared> for Vec<u8>` to extract the backing Vec from a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ exclude       = [
     ".travis.yml"
 ]
 
+[package.metadata.docs.rs]
+features = ["experimental"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+experimental = []
+
 [dependencies]
 
 [dev-dependencies]

--- a/src/divbuf.rs
+++ b/src/divbuf.rs
@@ -335,6 +335,8 @@ impl DivBufShared {
     /// read-buf feature stabilizes.
     ///
     /// <https://github.com/rust-lang/rust/issues/78485>
+    #[cfg(any(feature = "experimental", docsrs))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[allow(clippy::uninit_vec)] // Needs the read-buf feature to fix
     pub fn uninitialized(capacity: usize) -> Self {
         let mut v = Vec::<u8>::with_capacity(capacity);

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -280,6 +280,7 @@ mod divbufshared {
         assert!(dbs.try_mut().is_err());
     }
 
+    #[cfg(feature = "experimental")]
     #[test]
     pub fn uninitialized() {
         let cap = 4096;


### PR DESCRIPTION
Since the method is technically UB, it shouldn't be part of the stable API.