### PR TITLE
Fix the docs build on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Fixed the documentation on docs.rs.  No code change.
+  ([#27](https://github.com/asomers/divbuf/pull/27))
+
 ## [0.4.0] - 2025-01-18
 ### Added
 - `DivBufInaccessible` has neither read nor write access, but it is `Clone`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 //!
 //! This crate is similar to [`bytes`], but with a few key differences:
 //! - `bytes` is a COW crate.  Data will be shared between multiple objects as
-//!    much as possible, but sometimes the data will be copied to new storage.
-//!    `divbuf`, onthe other hand, will _never_ copy data unless explicitly
-//!    requested.
+//!   much as possible, but sometimes the data will be copied to new storage.
+//!   `divbuf`, onthe other hand, will _never_ copy data unless explicitly
+//!   requested.
 //! - A `BytesMut` object always has the sole ability to access its own data.
 //!   Once a `BytesMut` object is created, there is no other way to modify or
 //!   even read its data that doesn't involve that object.  A `DivBufMut`, on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! ```
 //!
 //! [`bytes`]: https://carllerche.github.io/bytes/bytes/index.html
-
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 mod divbuf;


### PR DESCRIPTION
Need to add a `feature(doc_cfg)`

Also, fix a clippy::doc_overindented_list_items lint